### PR TITLE
Wrap everything but the factory in the unnamed namespace.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToAccelUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToAccelUKernels.cpp
@@ -27,6 +27,7 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
+
 class LLVMCPULowerToAccelUKernelsPass
     : public LLVMCPULowerToAccelUKernelsBase<LLVMCPULowerToAccelUKernelsPass> {
 public:
@@ -45,7 +46,6 @@ public:
     return success();
   }
 };
-} // namespace
 
 /// Returns `true` if an `outsOperand` value is initialized to zero.
 static bool isInitializedToZero(Value outsOperand) {
@@ -110,8 +110,6 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::MatmulOp op) {
       genericMicroKernelOp.getOperation());
 }
 
-namespace {
-
 template <typename OpType>
 struct LowerToAccelUKernelPattern : OpRewritePattern<OpType> {
   LowerToAccelUKernelPattern(MLIRContext *context)
@@ -130,8 +128,6 @@ struct LowerToAccelUKernelPattern : OpRewritePattern<OpType> {
   }
 };
 
-} // namespace
-
 void LLVMCPULowerToAccelUKernelsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
@@ -148,6 +144,8 @@ void LLVMCPULowerToAccelUKernelsPass::runOnOperation() {
     return signalPassFailure();
   }
 }
+
+} // namespace
 
 std::unique_ptr<OperationPass<>> createLLVMCPULowerToAccelUKernelsPass() {
   return std::make_unique<LLVMCPULowerToAccelUKernelsPass>();


### PR DESCRIPTION
I'm curious why some of pass impls have stuff outside the unnamed namespace (e.g. [LLVMCPULowerToUKernels](https://github.com/monorimet/SRT/blob/ean-dispatch-plugin/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp)) while others simply place most of them in the unnamed namespace (e.g. [LLVMCPUSplitReduction](https://github.com/monorimet/SRT/blob/ean-dispatch-plugin/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp)).

Unless there's a compelling reason for that, I'd like to propose we place most stuff in the local namespace.